### PR TITLE
Fix Zamora bitmap load order

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,17 +203,18 @@ const zamoraGame = {
   start(){
     canvas.width  = 609;
     canvas.height = 528;
+
+    /* capturar bitmap del laberinto */
+    const off   = Object.assign(document.createElement('canvas'), {width:609, height:528});
+    off.getContext('2d').drawImage(mazeImg,0,0);
+    this.pix = off.getContext('2d').getImageData(0,0,609,528).data;
+
     this.reset();
 
     /* mostrar GIFs */
     heroGif .style.display = 'block';
     enemyGif.style.display = 'block';
     this.zs[0].gif = enemyGif;
-
-    /* capturar bitmap del laberinto */
-    const off   = Object.assign(document.createElement('canvas'), {width:609, height:528});
-    off.getContext('2d').drawImage(mazeImg,0,0);
-    this.pix = off.getContext('2d').getImageData(0,0,609,528).data;
 
     window.onkeydown = e => this.keys[e.key]=true;
     window.onkeyup   = e => this.keys[e.key]=false;


### PR DESCRIPTION
## Summary
- set up Zamora bitmap before calling `reset()`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68404caa2f94833299e230bd35e0d08c