### PR TITLE
Reset score when life lost

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,7 +247,7 @@ const zamoraGame = {
   },
 
   partialReset(){
-    this.keys={}; this.frame=0;
+    this.keys={}; this.frame=0; this.score=0;
     this.moveFreq=6; this.nextSpawn=1800;
     for(const z of this.zs){
       if(z.gif !== enemyGif) z.gif.remove();


### PR DESCRIPTION
## Summary
- reset score in Zamora when a life is lost

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844e9a5e9b8833286e6d0dea5473ede