### PR TITLE
Fix pong AI and add timed score

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,9 +44,16 @@ back.onclick = () => {
 
 /* ====== PONG ====== */
 let P={up:false,down:false,s1:0,s2:0};
-const pong={pH:70,pW:10,bR:8,
-  init(){canvas.width=600;canvas.height=400;this.y1=this.y2=(canvas.height-this.pH)/2;this.x=canvas.width/2;this.y=canvas.height/2;this.vx=Math.random()>0.5?3:-3;this.vy=(Math.random()*2-1)*3;P.s1=P.s2=0;},
-  start(){this.init();
+const pong={pH:70,pW:10,bR:8,speed:3,lastSpeedInc:0,startTime:0,timeScore:0,
+  init(resetAll=false){
+    canvas.width=600;canvas.height=400;
+    this.y1=this.y2=(canvas.height-this.pH)/2;
+    this.x=canvas.width/2;this.y=canvas.height/2;
+    this.vx=Math.random()>0.5?this.speed:-this.speed;
+    this.vy=(Math.random()*2-1)*this.speed;
+    if(resetAll){P.s1=P.s2=0;this.speed=3;this.startTime=Date.now();this.lastSpeedInc=this.startTime;}
+  },
+  start(){this.init(true);
     window.onkeydown=e=>{if(e.key==='ArrowUp'||e.key==='w')P.up=true;if(e.key==='ArrowDown'||e.key==='s')P.down=true;};
     window.onkeyup  =e=>{if(e.key==='ArrowUp'||e.key==='w')P.up=false;if(e.key==='ArrowDown'||e.key==='s')P.down=false;};
     const loop=()=>{this.upd();this.draw();anim=requestAnimationFrame(loop);};loop();
@@ -54,8 +61,15 @@ const pong={pH:70,pW:10,bR:8,
   upd(){
     if(P.up&&this.y1>0)this.y1-=5;
     if(P.down&&this.y1+this.pH<canvas.height)this.y1+=5;
-    if(this.y<this.y2+this.pH/2&&this.y2>0)this.y2-=4;
-    else if(this.y>this.y2+this.pH/2&&this.y2+this.pH<canvas.height)this.y2+=4;
+    if(this.y2+this.pH/2<this.y)this.y2+=4;else if(this.y2+this.pH/2>this.y)this.y2-=4;
+    if(this.y2<0)this.y2=0;else if(this.y2+this.pH>canvas.height)this.y2=canvas.height-this.pH;
+    const now=Date.now();
+    this.timeScore=Math.floor((now-this.startTime)/1000)*10;
+    if(now-this.lastSpeedInc>=15000){
+      const sx=Math.sign(this.vx)||1, sy=Math.sign(this.vy)||1;
+      this.speed+=1;this.vx=sx*(Math.abs(this.vx)+1);this.vy=sy*(Math.abs(this.vy)+1);
+      this.lastSpeedInc=now;
+    }
     this.x+=this.vx;this.y+=this.vy;
     if(this.y-this.bR<0||this.y+this.bR>canvas.height){
       this.vy*=-1;
@@ -69,7 +83,8 @@ const pong={pH:70,pW:10,bR:8,
       this.vx*=-1;
       hitSound.currentTime=0;hitSound.play();
     }
-    if(this.x<0){P.s2++;this.init();}if(this.x>canvas.width){P.s1++;this.init();}
+    if(this.x<0){P.s2++;this.init();}
+    if(this.x>canvas.width){P.s1++;this.init();}
   },
   draw(){
     ctx.fillStyle='#111';ctx.fillRect(0,0,canvas.width,canvas.height);
@@ -77,7 +92,9 @@ const pong={pH:70,pW:10,bR:8,
     ctx.fillRect(10,this.y1,this.pW,this.pH);
     ctx.fillRect(canvas.width-20,this.y2,this.pW,this.pH);
     ctx.beginPath();ctx.arc(this.x,this.y,this.bR,0,Math.PI*2);ctx.fill();
-    ctx.font='20px sans-serif';ctx.fillText(P.s1,canvas.width/4,30);ctx.fillText(P.s2,canvas.width*3/4,30);
+    ctx.font='20px sans-serif';ctx.fillText(P.s1,canvas.width/4,30);
+    ctx.fillText(P.s2,canvas.width*3/4,30);
+    ctx.fillText(this.timeScore,canvas.width/2-10,30);
   }
 };
 


### PR DESCRIPTION
## Summary
- tweak pong enemy movement so it doesn't get stuck
- add a score that increases with time
- increase ball speed every 15 seconds

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c4d5da0fc8332bde7a85bcc391ebb