### PR TITLE
Fix Pong score overlap

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,9 +119,10 @@ const pong={pH:70,pW:10,bR:8,speed:3,lastSpeedInc:0,startTime:0,timeScore:0,titl
     ctx.restore();
     ctx.font='20px sans-serif';
     ctx.fillStyle='#fff';
-    ctx.fillText(P.s1,canvas.width/4,30);
-    ctx.fillText(P.s2,canvas.width*3/4,30);
-    ctx.fillText(this.timeScore,canvas.width/2-10,30);
+    const scoreY=80;
+    ctx.fillText(P.s1,canvas.width/4,scoreY);
+    ctx.fillText(P.s2,canvas.width*3/4,scoreY);
+    ctx.fillText(this.timeScore,canvas.width/2-10,scoreY);
   }
 };
 


### PR DESCRIPTION
## Summary
- move the Pong score display below the game title

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c52903fe083329a45f3960659e5e0